### PR TITLE
Gradle: Prevent build abort on link error

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -21,6 +21,10 @@ android {
         sourceCompatibility JavaVersion.VERSION_1_7
         targetCompatibility JavaVersion.VERSION_1_7
     }
+
+    lintOptions {
+      abortOnError false
+    }
 }
 
 dependencies {


### PR DESCRIPTION
Lint errors were preventing build tasks to complete, chose to ignore them.
